### PR TITLE
Convert session age to seconds when using Redis Driver

### DIFF
--- a/src/Drivers/Redis.ts
+++ b/src/Drivers/Redis.ts
@@ -18,7 +18,7 @@ import { RedisManagerContract, RedisConnectionContract } from '@ioc:Adonis/Addon
  * File driver to read/write session to filesystem
  */
 export class RedisDriver implements SessionDriverContract {
-	private ttl: number = typeof this.config.age === 'string' ? ms(this.config.age) : this.config.age
+	private ttl: number = typeof this.config.age === 'string' ? Math.round(ms(this.config.age) / 1000) : this.config.age
 
 	constructor(private config: SessionConfig, private redis: RedisManagerContract) {
 		if (!this.config.redisConnection) {


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Fix session age when passing it as a string while using the redis driver. 

For example, if you set the session age to "60s" the redis TTL will be 60000 instead of 60.

Here is a similar case https://github.com/adonisjs/session/blob/develop/src/SessionManager/index.ts#L82

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/session/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
