### PR TITLE
fix(types): add HttpContext bindings

### DIFF
--- a/src/types/extended.ts
+++ b/src/types/extended.ts
@@ -19,3 +19,9 @@ declare module '@adonisjs/core/types' {
     'session:migrated': { fromSessionId: string; toSessionId: string; session: Session }
   }
 }
+
+declare module '@adonisjs/core/http' {
+  interface HttpContext {
+    session: Session
+  }
+}


### PR DESCRIPTION
Hey there! :wave:

This PR adds the missing typing for the `HttpContext`.