### PR TITLE
feat: add db adapter

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,8 +13,10 @@ jobs:
   test_linux:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [20.10.0, 21.x]
+        db: [sqlite, postgres, mysql]
     services:
       redis:
         image: redis
@@ -29,8 +31,33 @@ jobs:
         image: amazon/dynamodb-local
         ports:
           - 8000:8000
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: session_test
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: session_test
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3306:3306
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Create DynamoDB Table
         env:
           AWS_ACCESS_KEY_ID: accessKeyId
@@ -49,7 +76,7 @@ jobs:
             --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install
@@ -61,6 +88,17 @@ jobs:
         env:
           REDIS_HOST: 0.0.0.0
           REDIS_PORT: 6379
+          DB_CONNECTION: ${{ matrix.db }}
+          PG_HOST: 0.0.0.0
+          PG_PORT: 5432
+          PG_USER: postgres
+          PG_PASSWORD: postgres
+          PG_DATABASE: session_test
+          MYSQL_HOST: 0.0.0.0
+          MYSQL_PORT: 3306
+          MYSQL_USER: root
+          MYSQL_PASSWORD: root
+          MYSQL_DATABASE: session_test
 
   test_windows:
     runs-on: windows-latest
@@ -68,9 +106,9 @@ jobs:
       matrix:
         node-version: [20.10.0, 21.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install
@@ -82,3 +120,4 @@ jobs:
         env:
           NO_REDIS: true
           NO_DYNAMODB: true
+          NO_DATABASE: true

--- a/commands/make_session_table.ts
+++ b/commands/make_session_table.ts
@@ -1,0 +1,26 @@
+/*
+ * @adonisjs/session
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { stubsRoot } from '../stubs/main.js'
+import { BaseCommand } from '@adonisjs/core/ace'
+
+/**
+ * Command to create the sessions table migration
+ */
+export default class MakeSessionTable extends BaseCommand {
+  static commandName = 'make:session-table'
+  static description = 'Create a migration for the sessions database table'
+
+  async run() {
+    const codemods = await this.createCodemods()
+    await codemods.makeUsingStub(stubsRoot, 'make/migration/sessions.stub', {
+      migration: { tableName: 'sessions', prefix: Date.now() },
+    })
+  }
+}

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   redis:
     image: redis:alpine
@@ -14,16 +12,43 @@ services:
     environment:
       - REDIS_URI=redis://redis:6379
 
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: session_test
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mysql:
+    image: mysql:8
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: session_test
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   dynamodb-local:
     image: amazon/dynamodb-local
     ports:
       - 8002:8000
-    command: '-jar DynamoDBLocal.jar -inMemory -sharedDb'
+    command: "-jar DynamoDBLocal.jar -inMemory -sharedDb"
     working_dir: /home/dynamodblocal
     healthcheck:
       test:
         [
-          'CMD-SHELL',
+          "CMD-SHELL",
           '[ "$(curl -s -o /dev/null -I -w ''%{http_code}'' http://localhost:8000)" == "400" ]',
         ]
       interval: 10s
@@ -36,11 +61,11 @@ services:
         condition: service_healthy
     image: amazon/aws-cli
     volumes:
-      - './tests_helpers/dynamodb_schemas:/tmp/dynamo'
+      - "./tests_helpers/dynamodb_schemas:/tmp/dynamo"
     environment:
-      AWS_ACCESS_KEY_ID: 'accessKeyId'
-      AWS_SECRET_ACCESS_KEY: 'secretAccessKey'
-      AWS_REGION: 'us-east-1'
+      AWS_ACCESS_KEY_ID: "accessKeyId"
+      AWS_SECRET_ACCESS_KEY: "secretAccessKey"
+      AWS_REGION: "us-east-1"
     entrypoint:
       - bash
     command: '-c "for f in /tmp/dynamo/*.json; do aws dynamodb create-table --endpoint-url "http://dynamodb-local:8000" --cli-input-json file://"$${f#./}"; done"'

--- a/configure.ts
+++ b/configure.ts
@@ -46,9 +46,10 @@ export async function configure(command: Configure) {
   ])
 
   /**
-   * Register provider
+   * Register provider and commands
    */
   await codemods.updateRcFile((rcFile) => {
     rcFile.addProvider('@adonisjs/session/session_provider')
+    rcFile.addCommand('@adonisjs/session/commands')
   })
 }

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
       "./src/plugins/japa/api_client.ts",
       "./src/plugins/japa/browser_client.ts",
       "./src/client.ts",
-      "./commands/make_session_table.ts",
+      "./commands/make_session_table.ts"
     ],
     "outDir": "./build",
     "clean": true,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "./plugins/api_client": "./build/src/plugins/japa/api_client.js",
     "./plugins/browser_client": "./build/src/plugins/japa/browser_client.js",
     "./client": "./build/src/client.js",
-    "./types": "./build/src/types.js"
+    "./types": "./build/src/types.js",
+    "./commands": "./build/commands/main.js"
   },
   "scripts": {
     "pretest": "npm run lint",
@@ -33,7 +34,8 @@
     "copy:templates": "copyfiles \"stubs/**/*.stub\" --up=\"1\" build",
     "precompile": "npm run lint",
     "compile": "tsup-node && tsc --emitDeclarationOnly --declaration",
-    "postcompile": "npm run copy:templates",
+    "postcompile": "npm run copy:templates && npm run index:commands",
+    "index:commands": "adonis-kit index build/commands",
     "build": "npm run compile",
     "version": "npm run build",
     "prepublishOnly": "npm run build",
@@ -45,6 +47,10 @@
     "@adonisjs/core": "^6.18.0",
     "@adonisjs/eslint-config": "^2.1.0",
     "@adonisjs/i18n": "^2.2.0",
+    "@adonisjs/lucid": "^21.6.0",
+    "better-sqlite3": "^12.5.0",
+    "mysql2": "^3.15.3",
+    "pg": "^8.16.3",
     "@adonisjs/prettier-config": "^1.4.5",
     "@adonisjs/redis": "^9.2.0",
     "@adonisjs/tsconfig": "^1.4.1",
@@ -84,6 +90,7 @@
   },
   "peerDependencies": {
     "@adonisjs/core": "^6.6.0",
+    "@adonisjs/lucid": "^21.0.0",
     "@adonisjs/redis": "^8.0.1 || ^9.0.0",
     "@aws-sdk/client-dynamodb": "^3.658.0",
     "@aws-sdk/util-dynamodb": "^3.658.0",
@@ -92,6 +99,9 @@
     "edge.js": "^6.0.2"
   },
   "peerDependenciesMeta": {
+    "@adonisjs/lucid": {
+      "optional": true
+    },
     "@adonisjs/redis": {
       "optional": true
     },
@@ -139,7 +149,8 @@
       "./src/plugins/edge.ts",
       "./src/plugins/japa/api_client.ts",
       "./src/plugins/japa/browser_client.ts",
-      "./src/client.ts"
+      "./src/client.ts",
+      "./commands/make_session_table.ts",
     ],
     "outDir": "./build",
     "clean": true,

--- a/src/define_config.ts
+++ b/src/define_config.ts
@@ -8,11 +8,12 @@
  */
 
 /// <reference types="@adonisjs/redis/redis_provider" />
+/// <reference types="@adonisjs/lucid/database_provider" />
 
 import string from '@poppinss/utils/string'
 import { configProvider } from '@adonisjs/core'
 import type { ConfigProvider } from '@adonisjs/core/types'
-import { InvalidArgumentsException } from '@poppinss/utils'
+import { InvalidArgumentsException, RuntimeException } from '@poppinss/utils'
 import type { CookieOptions } from '@adonisjs/core/types/http'
 
 import debug from './debug.js'
@@ -23,6 +24,7 @@ import type {
   RedisStoreConfig,
   SessionStoreFactory,
   DynamoDBStoreConfig,
+  DatabaseStoreConfig,
 } from './types.js'
 
 /**
@@ -123,6 +125,7 @@ export const stores: {
   redis: (config: RedisStoreConfig) => ConfigProvider<SessionStoreFactory>
   cookie: () => ConfigProvider<SessionStoreFactory>
   dynamodb: (config: DynamoDBStoreConfig) => ConfigProvider<SessionStoreFactory>
+  database: (config?: DatabaseStoreConfig) => ConfigProvider<SessionStoreFactory>
 } = {
   file: (config) => {
     return configProvider.create(async () => {
@@ -162,6 +165,26 @@ export const stores: {
         return new DynamoDBStore(client, sessionConfig.age, {
           tableName: config.tableName,
           keyAttribute: config.keyAttribute,
+        })
+      }
+    })
+  },
+  database: (config) => {
+    return configProvider.create(async (app) => {
+      const { DatabaseStore } = await import('./stores/database.js')
+      const db = await app.container.make('lucid.db')
+      const connectionName = config?.connectionName || db.primaryConnectionName
+
+      if (!db.manager.has(connectionName)) {
+        throw new RuntimeException(
+          `Invalid database connection "${connectionName}" referenced in session config`
+        )
+      }
+
+      return (_, sessionConfig: SessionConfig) => {
+        return new DatabaseStore(db.connection(connectionName), sessionConfig.age, {
+          tableName: config?.tableName,
+          gcProbability: config?.gcProbability,
         })
       }
     })

--- a/src/stores/database.ts
+++ b/src/stores/database.ts
@@ -1,0 +1,146 @@
+/**
+ * @adonisjs/session
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import string from '@poppinss/utils/string'
+import { MessageBuilder } from '@adonisjs/core/helpers'
+import type { QueryClientContract } from '@adonisjs/lucid/types/database'
+
+import debug from '../debug.js'
+import type { SessionStoreContract, SessionData } from '../types.js'
+
+/**
+ * Database store to read/write session to SQL databases using Lucid
+ */
+export class DatabaseStore implements SessionStoreContract {
+  #client: QueryClientContract
+  #tableName: string
+  #ttlSeconds: number
+  #gcProbability: number
+
+  constructor(
+    client: QueryClientContract,
+    age: string | number,
+    options?: {
+      /**
+       * Defaults to "sessions"
+       */
+      tableName?: string
+
+      /**
+       * The probability (in percent) that garbage collection will be
+       * triggered on any given request. For example, 2 means 2% chance.
+       *
+       * Set to 0 to disable garbage collection.
+       *
+       * Defaults to 2 (2% chance)
+       */
+      gcProbability?: number
+    }
+  ) {
+    this.#client = client
+    this.#tableName = options?.tableName ?? 'sessions'
+    this.#ttlSeconds = string.seconds.parse(age)
+    this.#gcProbability = options?.gcProbability ?? 2
+    debug('initiating database store')
+  }
+
+  /**
+   * Run garbage collection to delete expired sessions.
+   * This is called based on gcProbability after writing session data.
+   */
+  async #collectGarbage(): Promise<void> {
+    if (this.#gcProbability <= 0) {
+      return
+    }
+
+    const random = Math.random() * 100
+    if (random < this.#gcProbability) {
+      debug('database store: running garbage collection')
+      const expiredBefore = new Date(Date.now())
+      await this.#client.from(this.#tableName).where('expires_at', '<=', expiredBefore).delete()
+    }
+  }
+
+  /**
+   * Returns session data
+   */
+  async read(sessionId: string): Promise<SessionData | null> {
+    debug('database store: reading session data %s', sessionId)
+
+    const row = await this.#client.from(this.#tableName).where('id', sessionId).first()
+
+    if (!row) {
+      return null
+    }
+
+    /**
+     * Check if the session has expired. If so, delete it and return null.
+     */
+    const expiresAt = new Date(row.expires_at).getTime()
+    if (Date.now() > expiresAt) {
+      await this.destroy(sessionId)
+      return null
+    }
+
+    /**
+     * Verify contents with the session id and return them as an object
+     */
+    try {
+      return new MessageBuilder().verify<SessionData>(row.data, sessionId)
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Write session values to the database
+   */
+  async write(sessionId: string, values: Object): Promise<void> {
+    debug('database store: writing session data %s, %O', sessionId, values)
+
+    const message = new MessageBuilder().build(values, undefined, sessionId)
+    const expiresAt = new Date(Date.now() + this.#ttlSeconds * 1000)
+
+    await this.#client
+      .insertQuery()
+      .table(this.#tableName)
+      .insert({
+        id: sessionId,
+        data: message,
+        expires_at: expiresAt,
+      })
+      .knexQuery.onConflict('id')
+      .merge(['data', 'expires_at'])
+
+    await this.#collectGarbage()
+  }
+
+  /**
+   * Cleanup session by removing it
+   */
+  async destroy(sessionId: string): Promise<void> {
+    debug('database store: destroying session data %s', sessionId)
+
+    await this.#client.from(this.#tableName).where('id', sessionId).delete()
+  }
+
+  /**
+   * Updates the session expiry
+   */
+  async touch(sessionId: string): Promise<void> {
+    debug('database store: touching session data %s', sessionId)
+
+    const expiresAt = new Date(Date.now() + this.#ttlSeconds * 1000)
+
+    await this.#client
+      .from(this.#tableName)
+      .where('id', sessionId)
+      .update({ expires_at: expiresAt })
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,25 @@ export type DynamoDBStoreConfig = (
 }
 
 /**
+ * Configuration used by the database store.
+ */
+export interface DatabaseStoreConfig {
+  connectionName?: string
+  tableName?: string
+
+  /**
+   * The probability (in percent) that garbage collection of expired
+   * sessions will be triggered on any given request.
+   *
+   * For example, 2 means 2% chance.
+   * Set to 0 to disable garbage collection.
+   *
+   * Defaults to 2 (2% chance)
+   */
+  gcProbability?: number
+}
+
+/**
  * Factory function to instantiate session store
  */
 export type SessionStoreFactory = (

--- a/stubs/make/migration/sessions.stub
+++ b/stubs/make/migration/sessions.stub
@@ -1,0 +1,25 @@
+{{{
+  exports({
+    to: app.makePath(
+      'database/migrations',
+      `${migration.prefix}_create_${migration.tableName}_table.ts`
+    )
+  })
+}}}
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = '{{ migration.tableName }}'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.string('id').primary()
+      table.text('data').notNullable()
+      table.timestamp('expires_at').notNullable().index()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/tests/stores/database_store.spec.ts
+++ b/tests/stores/database_store.spec.ts
@@ -1,0 +1,218 @@
+/*
+ * @adonisjs/session
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { setTimeout } from 'node:timers/promises'
+import { Database } from '@adonisjs/lucid/database'
+import { AppFactory } from '@adonisjs/core/factories/app'
+import { LoggerFactory } from '@adonisjs/core/factories/logger'
+import { EmitterFactory } from '@adonisjs/core/factories/events'
+
+import { DatabaseStore } from '../../src/stores/database.js'
+
+const sessionId = '1234'
+
+const dbConfig = {
+  connection: process.env.DB_CONNECTION || 'sqlite',
+  connections: {
+    sqlite: {
+      client: 'better-sqlite3' as const,
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    },
+    postgres: {
+      client: 'pg' as const,
+      connection: {
+        host: process.env.PG_HOST || '0.0.0.0',
+        port: Number(process.env.PG_PORT || 5432),
+        user: process.env.PG_USER || 'postgres',
+        password: process.env.PG_PASSWORD || 'postgres',
+        database: process.env.PG_DATABASE || 'session_test',
+      },
+    },
+    mysql: {
+      client: 'mysql2' as const,
+      connection: {
+        host: process.env.MYSQL_HOST || '0.0.0.0',
+        port: Number(process.env.MYSQL_PORT || 3306),
+        user: process.env.MYSQL_USER || 'root',
+        password: process.env.MYSQL_PASSWORD || 'root',
+        database: process.env.MYSQL_DATABASE || 'session_test',
+      },
+    },
+  },
+}
+
+async function createDatabase() {
+  const app = new AppFactory().create(new URL('./', import.meta.url), () => {})
+  await app.init()
+
+  return new Database(dbConfig, new LoggerFactory().create(), new EmitterFactory().create(app))
+}
+
+test.group('Database store', (group) => {
+  let db: Database
+
+  group.tap((t) => {
+    t.skip(!!process.env.NO_DATABASE, 'Database not available')
+  })
+
+  group.setup(async () => {
+    db = await createDatabase()
+
+    await db.connection().schema.createTable('sessions', (table) => {
+      table.string('id').primary()
+      table.text('data').notNullable()
+      table.timestamp('expires_at').notNullable()
+    })
+  })
+
+  group.each.setup(() => {
+    return async () => {
+      await db.from('sessions').delete()
+    }
+  })
+
+  group.teardown(async () => {
+    await db.connection().schema.dropTableIfExists('sessions')
+    await db.manager.closeAll()
+  })
+
+  test('return null when value is missing', async ({ assert }) => {
+    const store = new DatabaseStore(db.connection(), '2 hours')
+    const value = await store.read(sessionId)
+    assert.isNull(value)
+  })
+
+  test('save session data in database', async ({ assert }) => {
+    const store = new DatabaseStore(db.connection(), '2 hours')
+    await store.write(sessionId, { message: 'hello-world' })
+
+    const row = await db.from('sessions').where('id', sessionId).first()
+    assert.exists(row)
+    assert.equal(row.id, sessionId)
+    assert.exists(row.data)
+    assert.exists(row.expires_at)
+  })
+
+  test('read session data from database', async ({ assert }) => {
+    const store = new DatabaseStore(db.connection(), '2 hours')
+    await store.write(sessionId, { message: 'hello-world' })
+
+    const value = await store.read(sessionId)
+    assert.deepEqual(value, { message: 'hello-world' })
+  })
+
+  test('return null when session data is expired', async ({ assert }) => {
+    const store = new DatabaseStore(db.connection(), 1)
+    await store.write(sessionId, { message: 'hello-world' })
+
+    await setTimeout(2000)
+
+    const value = await store.read(sessionId)
+    assert.isNull(value)
+  }).disableTimeout()
+
+  test('delete expired session from database when reading', async ({ assert }) => {
+    const store = new DatabaseStore(db.connection(), 1)
+    await store.write(sessionId, { message: 'hello-world' })
+
+    await setTimeout(2000)
+
+    await store.read(sessionId)
+
+    const row = await db.from('sessions').where('id', sessionId).first()
+    assert.isNull(row)
+  }).disableTimeout()
+
+  test('ignore malformed contents', async ({ assert }) => {
+    const store = new DatabaseStore(db.connection(), '2 hours')
+    await db
+      .insertQuery()
+      .table('sessions')
+      .insert({
+        id: sessionId,
+        data: 'invalid-json',
+        expires_at: new Date(Date.now() + 7200000),
+      })
+
+    const value = await store.read(sessionId)
+    assert.isNull(value)
+  })
+
+  test('update existing session on write', async ({ assert }) => {
+    const store = new DatabaseStore(db.connection(), '2 hours')
+    await store.write(sessionId, { message: 'hello-world' })
+    await store.write(sessionId, { message: 'updated' })
+
+    const value = await store.read(sessionId)
+    assert.deepEqual(value, { message: 'updated' })
+
+    const count = await db.from('sessions').count('* as total')
+    assert.equal(count[0].total, 1)
+  })
+
+  test('delete session on destroy', async ({ assert }) => {
+    const store = new DatabaseStore(db.connection(), '2 hours')
+    await store.write(sessionId, { message: 'hello-world' })
+    await store.destroy(sessionId)
+
+    const row = await db.from('sessions').where('id', sessionId).first()
+    assert.isNull(row)
+  })
+
+  test('update session expiry on touch', async ({ assert }) => {
+    const store = new DatabaseStore(db.connection(), 10)
+    await store.write(sessionId, { message: 'hello-world' })
+
+    const rowBefore = await db.from('sessions').where('id', sessionId).first()
+    const expiryBefore = new Date(rowBefore.expires_at).getTime()
+
+    await setTimeout(2000)
+
+    await store.touch(sessionId)
+
+    const rowAfter = await db.from('sessions').where('id', sessionId).first()
+    const expiryAfter = new Date(rowAfter.expires_at).getTime()
+
+    assert.isAbove(expiryAfter, expiryBefore)
+  }).disableTimeout()
+
+  test('garbage collection cleans up expired sessions', async ({ assert }) => {
+    // Use gcProbability 100 to always trigger garbage collection
+    const store = new DatabaseStore(db.connection(), 1, { gcProbability: 100 })
+
+    // Write a session that will expire
+    await store.write('expired-session', { message: 'will-expire' })
+
+    await setTimeout(2000)
+
+    // Write another session (this triggers garbage collection)
+    await store.write('new-session', { message: 'fresh' })
+
+    // The expired session should have been cleaned up
+    const expiredRow = await db.from('sessions').where('id', 'expired-session').first()
+    assert.isNull(expiredRow)
+
+    // The new session should still exist
+    const newRow = await db.from('sessions').where('id', 'new-session').first()
+    assert.exists(newRow)
+  }).disableTimeout()
+
+  test('garbage collection does not run when disabled', async ({ assert }) => {
+    const store = new DatabaseStore(db.connection(), 1, { gcProbability: 0 })
+
+    await store.write('expired-session', { message: 'will-expire' })
+    await setTimeout(2000)
+    await store.write('new-session', { message: 'fresh' })
+
+    const expiredRow = await db.from('sessions').where('id', 'expired-session').first()
+    assert.exists(expiredRow)
+  }).disableTimeout()
+})


### PR DESCRIPTION
PR adds a new DB store for sessions
pretty standard stuff but two important things to note:

Automatic garbage collection of expired sessions uses a "probability" mechanism. means there is a 2% chance of cleaning up expired entries whenever new session data is written. The approach is inspired by Laravel, which I thought was pretty neat and smart way of dealing with this. see : https://github.com/laravel/laravel/blob/12.x/config/session.php#L117

Also instead of dealing with configure.ts and annoying prompts/conditionals, we now have `node ace make:session-table`, which you can execute to creates the migration